### PR TITLE
Rename control mode bit to measurement select bit

### DIFF
--- a/AXI4-lite_custom.srcs/sources_1/new/axi_lite_slave_regs_pkg.vhd
+++ b/AXI4-lite_custom.srcs/sources_1/new/axi_lite_slave_regs_pkg.vhd
@@ -34,7 +34,7 @@ package axi_lite_slave_regs_pkg is
 
   -- control and status 
   constant CTRL_START_BIT : natural := 0;  -- armar medicion
-  constant CTRL_MODE_BIT  : natural := 1;  -- 0=RESP, 1=RTT
+  constant CTRL_MEAS_SEL_BIT  : natural := 1;  -- 0=RESP, 1=RTT
 
   constant STAT_BUSY_BIT  : natural := 0;
   constant STAT_DONE_BIT  : natural := 1;


### PR DESCRIPTION
## Summary
- Rename `CTRL_MODE_BIT` constant to `CTRL_MEAS_SEL_BIT` in register package
- Keep `status_clear_done_err` and `control_clear_start` helper procedures
- Confirm `write_reg_by_index` uses a temporary `tmp` record before assigning to `regs`

## Testing
- `ghdl --version` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68adf29ba950832a97ef3e2c77033222